### PR TITLE
Readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ This action uses [rsync](https://linux.die.net/man/1/rsync "Rsync's Homepage") t
 
 ### `options`
 
-**Required** Rsync options. i.e. `--exclude` Default `""`.
+**Required** Rsync options. i.e. `--exclude`.
 
 ### `ssh_options`
 
-**Required** SSH command options. i.e. `-p 2222` Default `""`.
+**Required** SSH command options. i.e. `-p 2222`.
 
 ### `src`
 
-**Required** Local path to be synced. i.e. `public/` Default `./`.
+**Required** Local path to be synced. i.e. `public/`.
 
 ### `dest`
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This action uses [rsync](https://linux.die.net/man/1/rsync "Rsync's Homepage") t
 
 ### `options`
 
-**Required** Rsync options. i.e. exclude Default `""`.
+**Required** Rsync options. i.e. `--exclude` Default `""`.
 
 ### `ssh_options`
 
@@ -32,11 +32,11 @@ This action uses [rsync](https://linux.die.net/man/1/rsync "Rsync's Homepage") t
 
 ### `src`
 
-**Required** Local path to be synced.
+**Required** Local path to be synced. i.e. `public/` Default `./`.
 
 ### `dest`
 
-**Required** Remote server and path. i.e `user@server.com:/var/www/server.com/`
+**Required** Remote server and path. i.e `user@server.com:/var/www/server.com/`.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ This action uses [rsync](https://linux.die.net/man/1/rsync "Rsync's Homepage") t
 
 ### `ssh_options`
 
-**Required** SSH command options. i.e. "-p 2222" Default `""`.
+**Required** SSH command options. i.e. `-p 2222` Default `""`.
 
 ### `src`
 
 **Required** Local path to be synced.
 
-### `dst`
+### `dest`
 
-**Required** Remote server and path. i.e user@server.com:/var/www/server.com/
+**Required** Remote server and path. i.e `user@server.com:/var/www/server.com/`
 
 ## Outputs
 


### PR DESCRIPTION
### This PR: Readme Cleanup

There was some inconsistencies with the readme.

I've removed the `Defaults` from all required options, as having a default when its required doesn't make sense.

Fixed the typo with `dest` being `dst` which was fixed in other parts in #3 

Adding some mode code wrappers, to make things a little more readable.

Added an example to `src` since it did not have one in the definition (apart from below in the full examples)