### PR TITLE
Remove rsync flag `r` from default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   flags:
     description: 'Rsync flags'
     required: true
-    default: '-avzr --delete'
+    default: '-avz --delete'
   options:
     description: 'Rsync options (exclusion)'
     required: true


### PR DESCRIPTION
It's already included with `-a`.