### PR TITLE
Addressing deprecated 'set-output' warning.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ touch "$SSH_PATH/known_hosts"
 
 if [ -z "$DEPLOY_KEY" ];
 then
-  echo ::set-output name=status::'Action did not find the DEPLOY_KEY secret.'
+  echo "status=Action did not find the DEPLOY_KEY secret." >> $GITHUB_OUTPUT
   exit 1
 else
   printf '%b\n' "$DEPLOY_KEY" > "$SSH_PATH/deploy_key"
@@ -23,8 +23,8 @@ ssh-add "$SSH_PATH/deploy_key"
 
 if ! sh -c "rsync $1 -e 'ssh -i $SSH_PATH/deploy_key -o StrictHostKeyChecking=no $3' $2 $GITHUB_WORKSPACE/$4 $5"
 then
-  echo ::set-output name=status::'There was an issue syncing the content.'
+  echo "status=There was an issue syncing the content." >> $GITHUB_OUTPUT
   exit 1
 else
-  echo ::set-output name=status::'Content synced successfully.'
+  echo "status=Content synced successfully." >> $GITHUB_OUTPUT
 fi


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### This PR:

Running this action now generates the following warning:

`Warning: The "set-output" command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/`

**Bugfixes/Changed internals** 🎈
- Using `echo "status={status message}" >> $GITHUB_OUTPUT` construct instead, as recommended by GitHub

**Checklist** 🛡
- [x] Checks are passing.
- [x] Appropriate documentation has been written/updated (check if not applicable).
