### PR TITLE
Bump alpine, rsync and openssh versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.19
+FROM alpine:3.20
 
-LABEL version="2.0.0"
+LABEL version="3.0.0"
 LABEL maintainer="Pendect Tech Team <tech@pendect.com>" \
       org.label-schema.vendor="Pendect GmbH" \
       com.github.actions.name="RSyncer Action" \
@@ -8,7 +8,8 @@ LABEL maintainer="Pendect Tech Team <tech@pendect.com>" \
       com.github.actions.icon="truck" \
       com.github.actions.color="blue"
 
-RUN apk add --no-cache --virtual .run-deps rsync=3.3.0 openssh=9.7 && \
+RUN apk update && apk upgrade
+RUN apk add --no-cache --virtual .run-deps rsync openssh && \
     rm -rf /var/cache/apk/*
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.19
 
 LABEL version="2.0.0"
 LABEL maintainer="Pendect Tech Team <tech@pendect.com>" \
@@ -8,7 +8,7 @@ LABEL maintainer="Pendect Tech Team <tech@pendect.com>" \
       com.github.actions.icon="truck" \
       com.github.actions.color="blue"
 
-RUN apk add --no-cache --virtual .run-deps rsync=3.1.3-r1 openssh=8.1_p1-r0 && \
+RUN apk add --no-cache --virtual .run-deps rsync=3.3.0 openssh=9.7 && \
     rm -rf /var/cache/apk/*
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
### This PR: bumps versions of the libs used by the action

While using this action in one of my projects, it was failing due to outdated libs.
After updating, everything worked fine.

Those are the last versions on today's date:
- Rsync version 3.3.0 released (April 6th, 2024) - [source](https://rsync.samba.org/)
- OpenSSH version 9.7 released (2024-03-11) - [source](https://www.openssh.com/txt/release-9.7) 
- Alpine Linux 3.19 released (2023-12-07) - [source](https://www.alpinelinux.org/posts/Alpine-3.19.0-released.html)

**Checklist** 🛡
- [X] Checks are passing.
- [X] Appropriate documentation has been written/updated (check if not applicable).
